### PR TITLE
erlang patches for miner, fix writes in erl_child_setup_thread()

### DIFF
--- a/0003-erl_child_setup_thread.patch
+++ b/0003-erl_child_setup_thread.patch
@@ -48,10 +48,10 @@ index 0058b92..6032697 100644
  #endif /* #ifndef _ERL_UNIX_FORKER_H */
 diff --git a/erts/emulator/sys/unix/erl_child_setup_thread.c b/erts/emulator/sys/unix/erl_child_setup_thread.c
 new file mode 100644
-index 0000000..7a13a03
+index 0000000..cc9fb60
 --- /dev/null
 +++ b/erts/emulator/sys/unix/erl_child_setup_thread.c
-@@ -0,0 +1,1011 @@
+@@ -0,0 +1,1046 @@
 +/*
 + * %CopyrightBegin%
 + *
@@ -217,6 +217,41 @@ index 0000000..7a13a03
 +	    return nbytes;
 +	}
 +    }
++}
++
++static int write_exact(int fd, AddrByte *buff, int len)
++{
++    int res;
++    int x = len;
++    DEBUG_PRINT("%s: fd %d, buff %p, len %d\n", __func__, fd, buff, len);
++    for(;;) {
++	if((res = write(fd, buff, x)) == x) {
++	    break;
++	}
++        DEBUG_PRINT("   res %d, errno %d\n", res, errno);
++	if (res < 0) {
++	    if (errno == EINTR) {
++		continue;
++	    } else if (errno == EPIPE) {
++		return 0;
++	    }
++#ifdef ENXIO
++	    else if (errno == ENXIO) {
++		return 0;
++	    }
++#endif
++	    else {
++		return -1;
++	    }
++	} else {
++	    /* Hmmm, blocking write but not all written, could this happen
++	       if the other end was closed during the operation? Well,
++	       it costs very little to handle anyway... */
++	    x -= res;
++	    buff += res;
++	}
++    }
++    return len;
 +}
 +
 +static OpType get_op(AddrByte *buff)
@@ -691,7 +726,7 @@ index 0000000..7a13a03
 +    }
 +
 +    /* write response */
-+    if (data_size > 0 && write(rec->out_fd, reply, data_size) < 0) {
++    if (data_size > 0 && write_exact(rec->out_fd, reply, data_size) < 0) {
 +        warning("%s: write to out_fd %d, size %ld failed: %d (%s)\n",
 +                __func__, rec->out_fd, data_size, errno, strerror(errno));
 +    }
@@ -1049,12 +1084,12 @@ index 0000000..7a13a03
 +            proto.action = ErtsSysForkerProtoAction_Go;
 +            proto.u.go.os_pthread = new_child; /* aliased with proto.u.go.os_pid */
 +            proto.u.go.error_number = errno;
-+            while (write(pipes[1], &proto, sizeof(proto)) < 0 && errno == EINTR)
++            while (write_exact(pipes[1], (AddrByte*)&proto, sizeof(proto)) < 0 && errno == EINTR)
 +                ; /* remove gcc warning */
 +
 +#ifdef FORKER_PROTO_START_ACK
 +            proto.action = ErtsSysForkerProtoAction_StartAck;
-+            while (write(uds_fd, &proto, sizeof(proto)) < 0 && errno == EINTR)
++            while (write_exact(uds_fd, (AddrByte*)&proto, sizeof(proto)) < 0 && errno == EINTR)
 +                ; /* remove gcc warning */
 +#endif
 +        }

--- a/0004-erlexec-nodename-from-ifaddr.patch
+++ b/0004-erlexec-nodename-from-ifaddr.patch
@@ -1,0 +1,119 @@
+Derive node name from interface address
+
+Some erlang programs are controlled via the erlang RPC interface, reachable
+via a node name set on startup with the "-node" argument to erlexec. For
+example, the node name "foo@127.0.0.1" indicates that the node named 'foo' is
+reachable locally, via the loopback interface. However, erlang programs
+running on a Nanos unikernel cannot be controlled by a process on the same
+host and must instead be controlled over a network. When DHCP is used to
+assign network interfaces, the fully qualified node name cannot be known when
+staging the image with the preferred arguments. This patch allows the node
+name for an instance to be set using the address of a specified interface. The
+hostname in the -name argument may be set to "%<if>" where <if> is the
+interface name.
+
+For example, using the argument "-name foo@%en1" will cause erlexec to get the
+configured address of interface "en1", waiting for it to be assigned via DHCP
+if necessary, then use that address to compose the name as "foo@<ifaddr>",
+where <ifaddr> is the address assigned to the interface.
+
+diff --git a/erts/etc/common/erlexec.c b/erts/etc/common/erlexec.c
+index 4c279ac..329b4fa 100644
+--- a/erts/etc/common/erlexec.c
++++ b/erts/etc/common/erlexec.c
+@@ -26,7 +26,11 @@
+ #include "etc_common.h"
+ 
+ #if defined(RUN_FROM_EMU)
+-#  include "global.h"
++#include <sys/ioctl.h>
++#include <net/if.h>
++#include <netinet/in.h>
++#include <arpa/inet.h>
++#include "global.h"
+ #endif
+ 
+ #include "erl_driver.h"
+@@ -415,6 +419,70 @@ static void add_boot_config(void)
+ # define ADD_BOOT_CONFIG
+ #endif
+ 
++#ifdef RUN_FROM_EMU
++static char *process_nodename(char *namearg)
++{
++    int fd, waiting = 0;
++    char *hostname;
++    struct ifreq ifr;
++
++    hostname = strchr(namearg, '@');
++    if (!hostname)
++        return namearg;
++    hostname++;
++    if (hostname[0] != '%')
++        return namearg;
++
++    fd = socket(AF_INET, SOCK_DGRAM, 0);
++    if (fd < 0) {
++        fprintf(stderr, "%s: unable to open socket: %s\n", __func__, strerror(errno));
++        return namearg;
++    }
++
++    do {
++        struct sockaddr_in *sin;
++        ifr.ifr_addr.sa_family = AF_INET;
++        strncpy(ifr.ifr_name, hostname + 1, IFNAMSIZ-1);
++        if (ioctl(fd, SIOCGIFADDR, &ifr) < 0) {
++            fprintf(stderr, "%s: ioctl for SIOCGIFADDR failed: %s\n", __func__, strerror(errno));
++            close(fd);
++            return namearg;
++        }
++        sin = (struct sockaddr_in *)&ifr.ifr_addr;
++        if (sin->sin_addr.s_addr != 0) {
++            int sname_len = hostname - namearg;
++            int addr_len, total;
++            char *addr;
++            char *newnode;
++
++            if (waiting)
++                fprintf(stderr, "\n");
++            close(fd);
++            addr = inet_ntoa(sin->sin_addr);
++            addr_len = strlen(addr);
++            total = sname_len + addr_len + 1;
++            newnode = malloc(total);
++            if (!newnode) {
++                fprintf(stderr, "%s: unable to allocate %d bytes for node name\n", __func__, total);
++                return namearg;
++            }
++            strncpy(newnode, namearg, sname_len);
++            strncpy(newnode + sname_len, addr, addr_len + 1);
++            newnode[total - 1] = '\0';
++            fprintf(stderr, "%s: node name is \"%s\"\n", progname, newnode);
++            return newnode;
++        }
++        if (!waiting) {
++            waiting = 1;
++            fprintf(stderr, "%s: waiting for address assignment for interface \"%s\"...\n",
++                    progname, hostname + 1);
++        } else {
++            fprintf(stderr, ".");
++        }
++        sleep(1);
++    } while (1);
++}
++#endif
+ 
+ #ifdef __WIN32__
+ __declspec(dllexport) int win_erlexec(int argc, char **argv, HANDLE module, int windowed)
+@@ -745,7 +813,11 @@ int main(int argc, char **argv)
+ 			 */
+ 
+ 			add_arg(argv[i]);
++#ifdef RUN_FROM_EMU
++			add_arg(process_nodename(argv[i+1]));
++#else
+ 			add_arg(argv[i+1]);
++#endif
+ 			isdistributed = 1;
+ 			i++;
+ 		    } else if (strcmp(argv[i], "-noinput") == 0) {

--- a/0005-erl_child_setup_thread-netstat-for-inet_ext.patch
+++ b/0005-erl_child_setup_thread-netstat-for-inet_ext.patch
@@ -1,0 +1,170 @@
+Emulate netstat command used by the "inet_ext" package for erlang
+
+This adds a feature to erl_child_setup_thread() to parse and handle the
+command of the form "netstat -rn |grep <ifname>|grep default|awk '{print
+$2}'", used to obtain the default gateway address for interface <ifname>. This
+patch is only necessary for programs that depend on inet_ext (e.g. Helium
+Miner).
+
+diff --git a/erts/emulator/sys/unix/erl_child_setup_thread.c b/erts/emulator/sys/unix/erl_child_setup_thread.c
+index cc9fb60..b4d34ce 100644
+--- a/erts/emulator/sys/unix/erl_child_setup_thread.c
++++ b/erts/emulator/sys/unix/erl_child_setup_thread.c
+@@ -34,6 +34,11 @@
+ #include <sys/select.h>
+ #include <arpa/inet.h>
+ #include <pthread.h>
++#include <ifaddrs.h>
++#include <linux/netlink.h>
++#include <linux/rtnetlink.h>
++#include <arpa/inet.h>
++#include <net/if.h>
+ 
+ #define WANT_NONBLOCKING    /* must define this to pull in defs from sys.h */
+ #include "sys.h"
+@@ -787,6 +792,136 @@ static int simple_inet_gethost(int *pipes)
+     }
+ }
+ 
++static int simple_netstat(int *pipes, char *arg)
++{
++    /* for helium miner: extract gateway route using command of the form:
++       "netstat -rn |grep en1|grep default|awk '{print $2}'"
++    */
++
++    int fd;
++    int family = AF_INET;
++    struct sockaddr_nl nladdr;
++    struct req {
++        struct nlmsghdr nlh;
++        struct rtgenmsg msg;
++    } req;
++    uint8_t buf[4096];
++    struct iovec iov;
++    struct msghdr msg;
++    int ret, avail, expect_len;
++    char ifname[IF_NAMESIZE];
++    char gwaddr[INET_ADDRSTRLEN];
++    char *if_arg, *c;
++    int nlmsg_seq = 3;
++
++    DEBUG_PRINT("%s: arg: \"%s\"", __func__, arg);
++    if (strncmp(arg, "-rn", 3)) {
++        fprintf(stderr, "%s: unhandled netstat args: \"%s\"\n", __func__, arg);
++        return -1;
++    }
++    if_arg = strstr(arg, "en");
++    if (!if_arg || !(c = strchr(if_arg, '|'))) {
++        fprintf(stderr, "%s: could not parse interface from args: \"%s\"\n", __func__, arg);
++        return -1;
++    }
++    *c = '\0';
++    DEBUG_PRINT("if arg \"%s\"", if_arg);
++
++    fd = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
++    ASSERT(fd >= 0);
++    memset(&nladdr, '\0', sizeof(nladdr));
++    nladdr.nl_pid = 0;
++    nladdr.nl_family = AF_NETLINK;
++    ASSERT(bind(fd, (struct sockaddr *)&nladdr, sizeof(nladdr)) == 0);
++
++  retry:
++    nladdr.nl_pid = 0;
++    memset(&req, '\0', sizeof(req));
++    req.nlh.nlmsg_len = sizeof(req);
++    req.nlh.nlmsg_type = RTM_GETROUTE;
++    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++    req.nlh.nlmsg_pid = nladdr.nl_pid;
++    req.nlh.nlmsg_seq = nlmsg_seq++;
++    iov.iov_base = buf;
++    msg.msg_name = &nladdr;
++    msg.msg_namelen = sizeof(nladdr);
++    msg.msg_iov = &iov;
++    msg.msg_iovlen = 1;
++    msg.msg_control = NULL;
++    msg.msg_controllen = 0;
++    msg.msg_flags = 0;
++
++    req.msg.rtgen_family = family;
++    memcpy(iov.iov_base, &req, sizeof(req));
++    iov.iov_len = sizeof(req);
++    ret = sendmsg(fd, &msg, 0);
++    ERTS_ASSERT(ret == sizeof(req));
++    iov.iov_len = sizeof(buf);
++    avail = recvmsg(fd, &msg, 0);
++    expect_len = NLMSG_LENGTH(sizeof(struct rtmsg));
++    ERTS_ASSERT(avail >= expect_len);
++    ERTS_ASSERT(((struct nlmsghdr *)msg.msg_iov[0].iov_base)->nlmsg_len >= expect_len);
++
++    for (struct nlmsghdr *nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, avail);
++         nlh = NLMSG_NEXT(nlh, avail)) {
++        struct rtmsg *rtm = (struct rtmsg *)NLMSG_DATA(nlh);
++        int rta_len = RTM_PAYLOAD(nlh);
++        DEBUG_PRINT("nlmsg: len %d, type %d, flags %d, seq %d, pid %d",
++                    nlh->nlmsg_len, nlh->nlmsg_type, nlh->nlmsg_flags, nlh->nlmsg_seq, nlh->nlmsg_pid);
++        if (nlh->nlmsg_type == NLMSG_DONE)
++            break;
++        ifname[0] = '\0';
++        gwaddr[0] = '\0';
++        ASSERT(rtm->rtm_family == family);
++        if (rtm->rtm_table != RT_TABLE_MAIN)
++            continue;
++        DEBUG_PRINT("family %d, dst_len %d, src_len %d, tos %d, table %d, "
++                    "protocol %d, scope %d, type %d, flags 0x%x",
++                    rtm->rtm_family, rtm->rtm_dst_len, rtm->rtm_src_len, rtm->rtm_tos, rtm->rtm_table,
++                    rtm->rtm_protocol, rtm->rtm_scope, rtm->rtm_type, rtm->rtm_flags);
++        for (struct rtattr *rta = (struct rtattr *)RTM_RTA(rtm); RTA_OK(rta, rta_len);
++             rta = RTA_NEXT(rta, rta_len)) {
++            DEBUG_PRINT(" -> RTA type %d, len %d", rta->rta_type, rta->rta_len);
++            DEBUG_PRINT("   %d %d %d %d", *(unsigned char *)(RTA_DATA(rta) + 0),
++                        *(unsigned char *)(RTA_DATA(rta) + 1),
++                        *(unsigned char *)(RTA_DATA(rta) + 2),
++                        *(unsigned char *)(RTA_DATA(rta) + 3));
++
++            switch (rta->rta_type) {
++            case RTA_OIF:
++                if (!if_indextoname(*(unsigned int *)RTA_DATA(rta), ifname))
++                    fprintf(stderr, "if_indextoname failed: %d (%s)\n", errno, strerror(errno));
++                break;
++            case RTA_GATEWAY:
++                if (!inet_ntop(family, RTA_DATA(rta), gwaddr, sizeof(gwaddr)))
++                    goto inet_ntop_failed;
++                break;
++            }
++        }
++        if (ifname[0] && !strcmp(ifname, if_arg) && gwaddr[0]) {
++            int size, rv;
++            char gwstr[32];
++            size = snprintf(gwstr, 32, "%s\n", gwaddr);
++            rv = write_exact(pipes[1], (AddrByte*)gwstr, size);
++            DEBUG_PRINT("wrote \"%s\", %d bytes\n", gwstr, rv);
++            if (rv < size) {
++                warning("%s: failed to write response \"%s\" (%d bytes) rv %d, errno %d\n",
++                        __func__, gwstr, size, rv, errno);
++            }
++            goto done;
++        }
++    }
++    sleep(1);                   /* wait for DHCP */
++    goto retry;
++  done:
++    ASSERT(close(fd) == 0);
++    return 0;
++  inet_ntop_failed:
++    fprintf(stderr, "inet_ntop failed: %d (%s)\n", errno, strerror(errno));
++    ASSERT(close(fd) == 0);
++    return 1;
++}
++
+ static void *start_new_child(void *arg)
+ {
+     int *pipes = arg;
+@@ -938,6 +1073,8 @@ static void *start_new_child(void *arg)
+             DEBUG_PRINT("program name is \"%s\"", cmd);
+             if (!strcmp(cmd, "inet_gethost"))
+                 retcode = simple_inet_gethost(pipes);
++            else if (!strcmp(cmd, "netstat") && p)
++                retcode = simple_netstat(pipes, p + 1);
+             else
+                 warning("unhandled exec command: \"%s %s\"\n", cmd,
+                         p ? p + 1 : "");

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ Patch your repo:
 patch -p1 -ruN -d ~/otp < 0001-BEAM-embed-erlexec-and-EPMD.patch
 patch -p1 -ruN -d ~/otp < 0002-kernel-auth-erl-skip-cookie-file-permission-checks.patch
 patch -p1 -ruN -d ~/otp < 0003-erl_child_setup_thread.patch
+patch -p1 -ruN -d ~/otp < 0004-erlexec-nodename-from-ifaddr.patch
+patch -p1 -ruN -d ~/otp < 0005-erl_child_setup_thread-netstat-for-inet_ext.patch
 ```
+
+(Note that the last patch is only useful for packages that use the "inet_ext"
+package for erlang, such as Helium Miner.)
 
 Build:
 ```


### PR DESCRIPTION
This consists of two commits. The first one addresses a bug whereby
erl_child_setup_thread() was calling write() for pipes without handling the
partial write case, EINTR, etc. This change borrows write_exact() from
erl_child_setup.c and uses that in place of calls to write().

The second commit adds two patches necessary for running Helium
Miner: one to allow the modification of the Erlang node name to use the
configured address of a network interface, and another to interpret and
emulate shell commands used by the "inet_ext" package to find
the default gateway address.
