### PR TITLE
disable use of mremap()

### DIFF
--- a/0006-disable-mremap.patch
+++ b/0006-disable-mremap.patch
@@ -1,0 +1,22 @@
+disable use of mremap()
+
+This patch prevents avoids a crash that occurs when the address returned by
+mremap() is effectively being masked by ERTS_SUPERALIGNED_MASK, leading to a
+subsequent fault on unmapped memory. The root cause of this masking is still
+being investigated, but removing the definition of ERTS_HAVE_OS_MREMAP allows
+erlang/OTP to run without using mremap() for the time being.
+
+diff --git a/erts/emulator/sys/common/erl_mmap.h b/erts/emulator/sys/common/erl_mmap.h
+index a30b7d2..c29fb62 100644
+--- a/erts/emulator/sys/common/erl_mmap.h
++++ b/erts/emulator/sys/common/erl_mmap.h
+@@ -36,9 +36,6 @@
+ #if HAVE_MMAP
+ #  define ERTS_HAVE_OS_MMAP 1
+ #  define ERTS_HAVE_GENUINE_OS_MMAP 1
+-#  if HAVE_MREMAP
+-#    define ERTS_HAVE_OS_MREMAP 1
+-#  endif
+ /*
+  * MAP_NORESERVE is undefined in FreeBSD 10.x and later.
+  * This is to enable 64bit HiPE experimentally on FreeBSD.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ patch -p1 -ruN -d ~/otp < 0002-kernel-auth-erl-skip-cookie-file-permission-check
 patch -p1 -ruN -d ~/otp < 0003-erl_child_setup_thread.patch
 patch -p1 -ruN -d ~/otp < 0004-erlexec-nodename-from-ifaddr.patch
 patch -p1 -ruN -d ~/otp < 0005-erl_child_setup_thread-netstat-for-inet_ext.patch
+patch -p1 -ruN -d ~/otp < 0006-disable-mremap.patch
 ```
 
-(Note that the last patch is only useful for packages that use the "inet_ext"
+(Note that the patch 0005 is only useful for packages that use the "inet_ext"
 package for erlang, such as Helium Miner.)
 
 Build:


### PR DESCRIPTION
This patch prevents avoids a crash that occurs when the address returned by
mremap() is effectively being masked by ERTS_SUPERALIGNED_MASK, leading to a
subsequent fault on unmapped memory. The root cause of this masking is still
being investigated, but removing the definition of ERTS_HAVE_OS_MREMAP allows
erlang/OTP to run without using mremap() for the time being.
